### PR TITLE
Add Tests and TravisCI integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+
+include=cert_agent/cert_agent

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 
-include=cert_agent/cert_agent
+omit =
+    manage.py
+    wsgi.py

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ ENV/
 
 .idea
 /cert_agent/db.sqlite3
+
+.test-ve

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ python:
   - "2.7"
 install:
   - pip install -r test_requirements.txt
+  - pip install python-coveralls
 
 script:
-  - cd cert_agent && python manage.py test
+  - cd cert_agent && coverage run --source=../cert_agent manage.py test
+
+after_success:
+  - coveralls --base_dir=/home/travis/build/appsembler/tahoe_cert_agent/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+install:
+  - pip install -r test_requirements.txt
+
+script:
+  - cd cert_agent && python manage.py test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+all:
+	virtualenv .test-ve
+	./.test-ve/bin/pip install -r test_requirements.txt
+	./.test-ve/bin/flake8 cert_agent
+	cd cert_agent && ../.test-ve/bin/python manage.py check
+	cd cert_agent && ../.test-ve/bin/python manage.py test
+
+.PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	virtualenv .test-ve
+	virtualenv .test-ve -p python2.7
 	./.test-ve/bin/pip install -r test_requirements.txt
 	./.test-ve/bin/flake8 cert_agent
 	cd cert_agent && ../.test-ve/bin/python manage.py check

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 [![Build Status](https://travis-ci.org/appsembler/tahoe_cert_agent.svg?branch=master)](https://travis-ci.org/appsembler/tahoe_cert_agent)
+[![Coverage Status](https://coveralls.io/repos/github/appsembler/tahoe_cert_agent/badge.svg?branch=master)](https://coveralls.io/github/appsembler/tahoe_cert_agent?branch=master)
 
 Tahoe Cert Agent

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+[![Build Status](https://travis-ci.org/appsembler/tahoe_cert_agent.svg?branch=master)](https://travis-ci.org/appsembler/tahoe_cert_agent)
+
+Tahoe Cert Agent

--- a/cert_agent/cert_agent/settings.py
+++ b/cert_agent/cert_agent/settings.py
@@ -129,7 +129,7 @@ LOGGING = {
             'class': 'logging.StreamHandler',
         },
         'sentry': {
-            'level': 'ERROR', # To capture more than ERROR, change to WARNING, INFO, etc.
+            'level': 'ERROR',  # To capture more than ERROR, change to WARNING, INFO, etc.
             'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
         },
     },
@@ -147,8 +147,6 @@ RAVEN_CONFIG = {
     # release based on the git info.
     'release': raven.fetch_git_sha(os.path.abspath(os.pardir)),
 }
-
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/

--- a/cert_agent/cert_agent/tests/test_views.py
+++ b/cert_agent/cert_agent/tests/test_views.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from django.test.client import Client
+
+
+class IndexTest(TestCase):
+    def test_index(self):
+        """ dummy test to get things started
+
+        the index page just serves up a 404
+        """
+        c = Client()
+        response = c.get("/")
+        self.assertEqual(response.status_code, 404)

--- a/cert_agent/cert_agent/tests/test_views.py
+++ b/cert_agent/cert_agent/tests/test_views.py
@@ -1,13 +1,37 @@
-from django.test import TestCase
-from django.test.client import Client
+from django.test import RequestFactory, TestCase
+from ..views import DomainActivateView
 
 
-class IndexTest(TestCase):
-    def test_index(self):
-        """ dummy test to get things started
+class DomainActivateViewTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
 
-        the index page just serves up a 404
-        """
-        c = Client()
-        response = c.get("/")
-        self.assertEqual(response.status_code, 404)
+    def test_missing_api_key(self):
+        request = self.factory.post('/domain_activate/')
+        response = DomainActivateView.as_view()(request)
+        self.assertEqual(response.status_code, 403)
+
+    def test_missing_domain(self):
+        request = self.factory.post('/domain_activate/', HTTP_API_KEY='secret_key')
+        response = DomainActivateView.as_view()(request)
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_domain(self):
+        request = self.factory.post('/domain_activate/', HTTP_API_KEY='secret_key',
+                                    data={'domain': '!!! '})
+        response = DomainActivateView.as_view()(request)
+        self.assertEqual(response.status_code, 400)
+
+    def test_simple_command(self):
+        request = self.factory.post('/domain_activate/', HTTP_API_KEY='secret_key',
+                                    data={'domain': "www.example.com"})
+        with self.settings(ANSIBLE_CMD="true"):
+            response = DomainActivateView.as_view()(request)
+            self.assertEqual(response.status_code, 202)
+
+    def test_failed_command(self):
+        request = self.factory.post('/domain_activate/', HTTP_API_KEY='secret_key',
+                                    data={'domain': "www.example.com"})
+        with self.settings(ANSIBLE_CMD="false"):
+            response = DomainActivateView.as_view()(request)
+            self.assertEqual(response.status_code, 500)

--- a/cert_agent/cert_agent/tests/test_views.py
+++ b/cert_agent/cert_agent/tests/test_views.py
@@ -1,6 +1,8 @@
 from django.test import RequestFactory, TestCase
 from ..views import DomainActivateView
 
+from mock import patch
+
 
 class DomainActivateViewTests(TestCase):
     def setUp(self):
@@ -22,16 +24,30 @@ class DomainActivateViewTests(TestCase):
         response = DomainActivateView.as_view()(request)
         self.assertEqual(response.status_code, 400)
 
-    def test_simple_command(self):
+    @patch('cert_agent.views.log')
+    def test_simple_command(self, mock_logger):
         request = self.factory.post('/domain_activate/', HTTP_API_KEY='secret_key',
                                     data={'domain': "www.example.com"})
         with self.settings(ANSIBLE_CMD="true"):
             response = DomainActivateView.as_view()(request)
             self.assertEqual(response.status_code, 202)
+            mock_logger.debug.assert_called_with('Calling ansible script for domain www.example.com')
 
-    def test_failed_command(self):
+    @patch('cert_agent.views.log')
+    def test_multiline_command(self, mock_logger):
+        request = self.factory.post('/domain_activate/', HTTP_API_KEY='secret_key',
+                                    data={'domain': "www.example.com"})
+        with self.settings(ANSIBLE_CMD="echo 'one\ntwo\nthree'"):
+            response = DomainActivateView.as_view()(request)
+            self.assertEqual(response.status_code, 202)
+            # mock logger only remembers the last one it was called with
+            mock_logger.debug.assert_called_with('three\n')
+
+    @patch('cert_agent.views.log')
+    def test_failed_command(self, mock_logger):
         request = self.factory.post('/domain_activate/', HTTP_API_KEY='secret_key',
                                     data={'domain': "www.example.com"})
         with self.settings(ANSIBLE_CMD="false"):
             response = DomainActivateView.as_view()(request)
             self.assertEqual(response.status_code, 500)
+            mock_logger.error.assert_called_with("Ansible exited with non zero return code!")

--- a/cert_agent/manage.py
+++ b/cert_agent/manage.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django
+            import django  # flake8: noqa
         except ImportError:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+flake8==3.5.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@
 
 flake8==3.5.0
 coverage==4.5.1
+mock==2.0.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 
 flake8==3.5.0
+coverage==4.5.1


### PR DESCRIPTION
I have plans to make some changes here. So this adds a basic test suite that is run by travis and uses coveralls for coverage tracking.

I've got pretty good coverage of the important parts of the code. The `except CalledProcessError as e` block I have been unable to test though. AFAICT, it will only ever be raised when `subprocess.Popen()` is called with `check=True` and we are not passing in that argument. If there's some other way it can be raised, I haven't been able to duplicate it.