### PR TITLE
Call Ansible for just one domain cert generation

### DIFF
--- a/cert_agent/cert_agent/tests/test_views.py
+++ b/cert_agent/cert_agent/tests/test_views.py
@@ -41,7 +41,7 @@ class DomainActivateViewTests(TestCase):
             response = DomainActivateView.as_view()(request)
             self.assertEqual(response.status_code, 202)
             # mock logger only remembers the last one it was called with
-            mock_logger.debug.assert_called_with('three\n')
+            mock_logger.debug.assert_called_with('Calling ansible script for domain www.example.com')
 
     @patch('cert_agent.views.log')
     def test_failed_command(self, mock_logger):

--- a/cert_agent/cert_agent/views.py
+++ b/cert_agent/cert_agent/views.py
@@ -23,9 +23,9 @@ class DomainActivateView(APIView):
         log.debug("Calling ansible script for domain {}".format(domain))
 
         try:
-            process = Popen(settings.ANSIBLE_CMD, stdout=PIPE, stderr=STDOUT, shell=True)
-            for line in iter(process.stdout.readline, ''):
-                log.debug(line)
+            ansible_cmd = settings.ANSIBLE_CMD + " --extra-vars 'letsencrypt_single_cert=%s'" % domain
+            process = Popen(ansible_cmd, stdout=PIPE, stderr=STDOUT, shell=True)
+
             process.wait()
             if process.returncode != 0:
                 log.error("Ansible exited with non zero return code!")

--- a/cert_agent/cert_agent/views.py
+++ b/cert_agent/cert_agent/views.py
@@ -1,5 +1,6 @@
 from subprocess import CalledProcessError, STDOUT, Popen, PIPE
 import logging
+import re
 
 from rest_framework import status
 from rest_framework.response import Response
@@ -10,6 +11,7 @@ from django.conf import settings
 
 
 log = logging.getLogger(__name__)
+whitelist_pattern = re.compile("[^\.-_a-zA-Z0-9]")
 
 
 class DomainActivateView(APIView):
@@ -23,6 +25,8 @@ class DomainActivateView(APIView):
         log.debug("Calling ansible script for domain {}".format(domain))
 
         try:
+            # remove any potentially unsafe chars from `domain` before passing it to the shell
+            domain = whitelist_pattern.sub("", domain)
             ansible_cmd = settings.ANSIBLE_CMD + " --extra-vars 'letsencrypt_single_cert=%s'" % domain
             process = Popen(ansible_cmd, stdout=PIPE, stderr=STDOUT, shell=True)
 


### PR DESCRIPTION
This PR calls the ansible playbooks that generation the custom domain certificate, sending the new domain as a parameter, so we can generate the cert for a single domain. This PR works together with https://github.com/appsembler/configuration/pull/161 and https://github.com/appsembler/roles/pull/46/files.

The workflow switch happens when the bool `letsencrypt_execute_for_single_domain` is `true` this is set in https://github.com/appsembler/roles/pull/46/files, in the server vars defined for certbot.