### PR TITLE
add django-statsd-mozilla

### DIFF
--- a/cert_agent/cert_agent/settings.py
+++ b/cert_agent/cert_agent/settings.py
@@ -148,6 +148,21 @@ RAVEN_CONFIG = {
     'release': raven.fetch_git_sha(os.path.abspath(os.pardir)),
 }
 
+# statsd metrics
+if not DEBUG:
+    INSTALLED_APPS += ['django_statsd', ]
+
+    # these need to be at the beginning of the MIDDLEWARE
+    MIDDLEWARE = [
+        'django_statsd.middleware.GraphiteRequestTimingMiddleware',
+        'django_statsd.middleware.GraphiteMiddleware',
+    ] + MIDDLEWARE
+
+    STATSD_HOST = env('STATSD_HOST', default='stage-prometheus.infra.appsembler.com')
+    STATSD_PORT = env('STATSD_PORT', default=9125)
+    STATSD_CLIENT = 'statsd.client'
+    STATSD_PREFIX = env('STATSD_PREFIX', default='tahoe_cert_agent')
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 decorator==4.1.2
 Django==1.11.4
 django-environ==0.4.3
+django-statsd-mozilla==0.4.0
 djangorestframework==3.6.3
 pytz==2017.2
 raven==6.3.0
 six==1.10.0
+statsd==3.2.2
 validators==0.12.0
 gunicorn==19.7.1
 


### PR DESCRIPTION
like https://github.com/appsembler/amc/pull/82 this just adds the very basic statsd setup so we can begin capturing metrics. Initially, this will pretty much only be request rates and timing info (since there is no database in use). Mostly it sets us up to add custom metrics next.