### PR TITLE
log ansible output

### DIFF
--- a/cert_agent/cert_agent/settings.py
+++ b/cert_agent/cert_agent/settings.py
@@ -155,3 +155,4 @@ STATIC_URL = '/static/'
 
 API_SECRET_KEY = env('API_SECRET_KEY', default="secret_key")
 ANSIBLE_CMD = env('ANSIBLE_CMD', default="echo 'running ansible command'")
+ANSIBLE_LOG_DIR = env('ANSIBLE_LOG_DIR', default="/var/log/tahoe_cert_agent/")

--- a/cert_agent/cert_agent/tests/test_views.py
+++ b/cert_agent/cert_agent/tests/test_views.py
@@ -1,5 +1,6 @@
+from datetime import datetime
 from django.test import RequestFactory, TestCase
-from ..views import DomainActivateView
+from ..views import DomainActivateView, log_filename
 
 from mock import patch
 
@@ -51,3 +52,11 @@ class DomainActivateViewTests(TestCase):
             response = DomainActivateView.as_view()(request)
             self.assertEqual(response.status_code, 500)
             mock_logger.error.assert_called_with("Ansible exited with non zero return code!")
+
+
+class TestHelpers(TestCase):
+    def test_log_filename(self):
+        d = datetime(year=2018, month=1, day=1, hour=12, minute=0, second=0)
+        domain = "foo.example.com"
+        r = log_filename(domain, now=d)
+        self.assertEqual(r, "2018-01-01T12:00:00-foo.example.com.log")


### PR DESCRIPTION
Explicitly log each ansible run to a separate file for easier debugging. Currently, the output is *supposed* to be printing out to STDERR, and systemd should be logging that, but something in that process isn't working. The [ANSIBLE_LOG_PATH](https://docs.ansible.com/ansible/2.4/config.html#envvar-ANSIBLE_LOG_PATH) variable tells ansible to turn on logging and log to the specified file. That should bypass whatever is going on with systemd.

Log directory set by `ANSIBLE_LOG_DIR` environment variable.

This will require that that directory exists and is writable by the user. I will put in a separate PR to the `roles` repo to handle that.