### PR TITLE
switch TravisCI to VM-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 python:
   - "2.7"
 install:


### PR DESCRIPTION
see: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration