### PR TITLE
add honeycomb config

### DIFF
--- a/cert_agent/cert_agent/gunicorn_conf.py
+++ b/cert_agent/cert_agent/gunicorn_conf.py
@@ -5,7 +5,8 @@ import beeline
 
 def post_worker_init(worker):
     logging.info(f'beeline initialization in process pid {os.getpid()}')
-    beeline.init(
-        writekey=os.environ.get('HONEYCOMB_WRITEKEY'),
-        dataset=os.environ.get('HONEYCOMB_DATASET'),
-        service_name='cert_agent')
+if os.environ.get('HONEYCOMB_WRITEKEY'):
+        beeline.init(
+            writekey=os.environ['HONEYCOMB_WRITEKEY'],
+            dataset=os.environ['HONEYCOMB_DATASET'],
+            service_name='cert_agent')

--- a/cert_agent/cert_agent/gunicorn_conf.py
+++ b/cert_agent/cert_agent/gunicorn_conf.py
@@ -1,0 +1,11 @@
+import logging
+import os
+import beeline
+
+
+def post_worker_init(worker):
+    logging.info(f'beeline initialization in process pid {os.getpid()}')
+    beeline.init(
+        writekey=os.environ.get('HONEYCOMB_WRITEKEY'),
+        dataset=os.environ.get('HONEYCOMB_DATASET'),
+        service_name='cert_agent')

--- a/cert_agent/cert_agent/gunicorn_conf.py
+++ b/cert_agent/cert_agent/gunicorn_conf.py
@@ -5,7 +5,7 @@ import beeline
 
 def post_worker_init(worker):
     logging.info(f'beeline initialization in process pid {os.getpid()}')
-if os.environ.get('HONEYCOMB_WRITEKEY'):
+    if os.environ.get('HONEYCOMB_WRITEKEY'):
         beeline.init(
             writekey=os.environ['HONEYCOMB_WRITEKEY'],
             dataset=os.environ['HONEYCOMB_DATASET'],

--- a/cert_agent/cert_agent/settings.py
+++ b/cert_agent/cert_agent/settings.py
@@ -53,6 +53,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'beeline.middleware.django.HoneyMiddleware',
 ]
 
 ROOT_URLCONF = 'cert_agent.urls'
@@ -172,3 +173,7 @@ STATIC_URL = '/static/'
 API_SECRET_KEY = env('API_SECRET_KEY', default="secret_key")
 ANSIBLE_CMD = env('ANSIBLE_CMD', default="echo 'running ansible command'")
 ANSIBLE_LOG_DIR = env('ANSIBLE_LOG_DIR', default="/var/log/tahoe_cert_agent/")
+
+# Honeycomb
+HONEYCOMB_WRITEKEY = env.get_value('HONEYCOMB_WRITEKEY', default=None)
+HONEYCOMB_DATASET = env.get_value('HONEYCOMB_DATASET', default=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ six==1.10.0
 statsd==3.2.2
 validators==0.12.0
 gunicorn==19.7.1
-
+honeycomb-beeline==2.12.1


### PR DESCRIPTION
The basic config is in there and should be backward compatible with an environment that doesn't set the honeycomb variables (the middleware just does nothing if it's not been `init`ed). To deploy it, we'll need to add it to the ansible role and set things in `edx-configs`.