### PR TITLE
remove f-string

### DIFF
--- a/cert_agent/cert_agent/gunicorn_conf.py
+++ b/cert_agent/cert_agent/gunicorn_conf.py
@@ -4,7 +4,7 @@ import beeline
 
 
 def post_worker_init(worker):
-    logging.info(f'beeline initialization in process pid {os.getpid()}')
+    logging.info('beeline initialization in process pid {}'.format(os.getpid()))
     if os.environ.get('HONEYCOMB_WRITEKEY'):
         beeline.init(
             writekey=os.environ['HONEYCOMB_WRITEKEY'],


### PR DESCRIPTION
cert_agent still runs on python 2.7 so no fancy f-strings for us yet