### PR TITLE
switch from TravisCI to github actions for CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,20 @@
+name: Tox
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.8, 3.6, 2.7]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Test with tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+          tox -e py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-  - "2.7"
-  - "3.6"
-install:
-  - pip install tox-travis
-  
-script:
-  - POST_COMMAND=coveralls tox

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/appsembler/tahoe_cert_agent.svg?branch=master)](https://travis-ci.org/appsembler/tahoe_cert_agent)
 [![Coverage Status](https://coveralls.io/repos/github/appsembler/tahoe_cert_agent/badge.svg?branch=master)](https://coveralls.io/github/appsembler/tahoe_cert_agent?branch=master)
 
 Tahoe Cert Agent

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skipsdist = True
 deps = -r{toxinidir}/test_requirements.txt
        coveralls
 
-passenv = TRAVIS TRAVIS_*
 changedir = cert_agent
 
 commands =


### PR DESCRIPTION
run our tests on github actions instead of TravisCI. Will figure out how to get coveralls working properly again later.

I've also got a `flake8` config ready to go, but it's currently not passing so I will also add that later after this is applied.